### PR TITLE
[fix] workaround for wrong length-value in cut-files, for images they de...

### DIFF
--- a/src/ServiceSupport.py
+++ b/src/ServiceSupport.py
@@ -280,6 +280,8 @@ class Info:
 			length = info and info.getLength(service) or 0
 		if length <= 0:
 			length = self.__cutlist and self.__cutlist.getCutListLength()
+		if length > 86400:
+			length = 0
 		return length or 0
 	
 	def getBeginTime(self):


### PR DESCRIPTION
...liver this from time to time on some files. Otherwise it can be happen that the "IMDbEventViewSimple" is hiding and you can go out from Emc after that.